### PR TITLE
Use a generic Wrapper<T>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,10 @@
         <artifactId>kemitix-parent</artifactId>
         <version>3.2.4</version>
     </parent>
-    <artifactId>print-stream-interceptor</artifactId>
-    <version>0.1.0</version>
-    <name>PrintStream Interceptor</name>
-    <description>Stackable interceptors for PrintStream with copy, redirect, filter and passthrough.</description>
+    <artifactId>print-stream-wrapper</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>PrintStream Wrapper</name>
+    <description>Wrappers for PrintStream with copy, redirect, filter and passthrough implementations.</description>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/net/kemitix/wrapper/Wrapper.java
+++ b/src/main/java/net/kemitix/wrapper/Wrapper.java
@@ -1,0 +1,64 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.kemitix.wrapper;
+
+import java.util.Optional;
+
+/**
+ * Wrapper for generic types.
+ *
+ * @param <T> the type of object to wrap
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+public interface Wrapper<T> {
+
+    /**
+     * Fetch the core item being Wrapper.
+     *
+     * @return the core item
+     */
+    T getCore();
+
+    /**
+     * Gets the inner wrapper if one is present.
+     *
+     * @return An Optional containing the inner wrapper if present, otherwise is empty
+     */
+    Optional<Wrapper<T>> findInnerWrapper();
+
+    /**
+     * Remove the wrapper from the chain of wrappers.
+     *
+     * <p>Can't be <em>this</em> wrapper.</p>
+     *
+     * @param wrapper the wrapper to remove
+     */
+    void remove(Wrapper<T> wrapper);
+
+    /**
+     * Provides the core item's own interface.
+     *
+     * @return the core item as a T object
+     */
+    T asCore();
+}

--- a/src/main/java/net/kemitix/wrapper/package-info.java
+++ b/src/main/java/net/kemitix/wrapper/package-info.java
@@ -19,45 +19,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.kemitix.interceptor.printstream;
-
-import java.io.PrintStream;
-import java.util.Optional;
-
-/**
- * Intercept writes to a {@code PrintStream}.
- *
- * @author Paul Campbell (pcampbell@kemitix.net)
- */
-public interface PrintStreamInterceptor {
-
-    /**
-     * Fetch the PrintStream being intercepted.
-     *
-     * @return the intercepted PrintStream
-     */
-    PrintStream getPrintStream();
-
-    /**
-     * Gets the PrintStreamInterceptor wrapped by this interceptor, if one is present.
-     *
-     * @return An Optional containing the wrapped interceptor if present, otherwise is empty
-     */
-    Optional<PrintStreamInterceptor> getWrappedInterceptor();
-
-    /**
-     * Remove the interceptor from the chain to interceptors.
-     *
-     * <p>Can't be this interceptor.</p>
-     *
-     * @param interceptor the interceptor to remove
-     */
-    void remove(PrintStreamInterceptor interceptor);
-
-    /**
-     * Provides the Interceptor's PrintStream interface.
-     *
-     * @return a PrintStream
-     */
-    PrintStream asPrintStream();
-}
+package net.kemitix.wrapper;

--- a/src/main/java/net/kemitix/wrapper/printstream/CopyPrintStreamWrapper.java
+++ b/src/main/java/net/kemitix/wrapper/printstream/CopyPrintStreamWrapper.java
@@ -19,53 +19,54 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.kemitix.interceptor.printstream;
+package net.kemitix.wrapper.printstream;
 
 import lombok.NonNull;
+import net.kemitix.wrapper.Wrapper;
 
 import java.io.PrintStream;
 
 /**
- * Interceptor for {@link PrintStream} that Redirects all writes to the supplied PrintStream and ignores the intercepted
- * PrintStream, or other interceptor.
+ * Wrapper for {@link PrintStream} that copies all writes to the supplied PrintStream and to any inner wrapper or, if
+ * there isn't one, to the core {@link PrintStream}.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public class RedirectPrintStreamInterceptor extends PassthroughPrintStreamInterceptor {
+public class CopyPrintStreamWrapper extends PassthroughPrintStreamWrapper {
 
-    private final PrintStream redirectTo;
+    private final PrintStream copyTo;
 
     /**
-     * Constructor to intercept in existing PrintStream.
+     * Constructor to wrap in existing PrintStream.
      *
-     * @param original   the PrintStream to intercept
-     * @param redirectTo the PrintStream to redirect writes to
+     * @param core   the PrintStream to wrap
+     * @param copyTo the PrintStream to copy to
      */
-    public RedirectPrintStreamInterceptor(final PrintStream original, @NonNull final PrintStream redirectTo) {
-        super(original);
-        this.redirectTo = redirectTo;
+    public CopyPrintStreamWrapper(final PrintStream core, @NonNull final PrintStream copyTo) {
+        super(core);
+        this.copyTo = copyTo;
     }
 
     /**
-     * Constructor to intercept in existing PrintStreamInterceptor.
+     * Constructor to wrap an existing {@code Wrapper<PrintStream>}.
      *
-     * @param interceptor the interceptor to intercept
-     * @param redirectTo  the PrintStream to redirect writes to
+     * @param wrapper the wrapper to wrap
+     * @param copyTo  the PrintStream to copy to
      */
-    public RedirectPrintStreamInterceptor(
-            final PrintStreamInterceptor interceptor, @NonNull final PrintStream redirectTo
-                                         ) {
-        super(interceptor);
-        this.redirectTo = redirectTo;
+    public CopyPrintStreamWrapper(final Wrapper<PrintStream> wrapper, @NonNull final PrintStream copyTo) {
+        super(wrapper);
+        this.copyTo = copyTo;
     }
 
     @Override
     public final void write(final int b) {
-        redirectTo.write(b);
+        super.write(b);
+        copyTo.write(b);
     }
 
     @Override
     public final void write(final byte[] buf, final int off, final int len) {
-        redirectTo.write(buf, off, len);
+        super.write(buf, off, len);
+        copyTo.write(buf, off, len);
     }
 }

--- a/src/main/java/net/kemitix/wrapper/printstream/FilteredPrintStreamWrapper.java
+++ b/src/main/java/net/kemitix/wrapper/printstream/FilteredPrintStreamWrapper.java
@@ -19,45 +19,48 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.kemitix.interceptor.printstream;
+package net.kemitix.wrapper.printstream;
+
+import lombok.NonNull;
+import net.kemitix.wrapper.Wrapper;
 
 import java.io.PrintStream;
 import java.util.function.Predicate;
 
 /**
- * Interceptor for {@link PrintStream} that tests Strings with a supplied {@link Predicate} before writing to the
- * intercepted PrintStream, or to another interceptor.
+ * Wrapper for {@link PrintStream} that tests Strings with a supplied {@link Predicate} before writing to any inner
+ * wrapper or, if there isn't one, to the core {@link PrintStream}.
  *
- * <p>If the Predicate returns {@code false} for the String, then it will not be written.</p>
+ * <p>If the Predicate returns {@code false} for the String, then the String will not be written.</p>
  *
  * <p>N.B. only {@link #print(String)} and {@link #println(String)} will be checked against the Predicate. All other
  * {@code #write(*)}, {@code #print(*)} or {@code #println(*)} calls will always be written.</p>
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public class FilteredPrintStreamInterceptor extends PassthroughPrintStreamInterceptor {
+public class FilteredPrintStreamWrapper extends PassthroughPrintStreamWrapper {
 
     private final Predicate<String> predicate;
 
     /**
-     * Constructor to intercept in existing PrintStream.
+     * Constructor to wrap in existing PrintStream.
      *
-     * @param original  the PrintStream to intercept
+     * @param core      the PrintStream to wrap
      * @param predicate the predicate to apply to strings
      */
-    public FilteredPrintStreamInterceptor(final PrintStream original, final Predicate<String> predicate) {
-        super(original);
+    public FilteredPrintStreamWrapper(final PrintStream core, @NonNull final Predicate<String> predicate) {
+        super(core);
         this.predicate = predicate;
     }
 
     /**
-     * Constructor to intercept in existing PrintStreamInterceptor.
+     * Constructor to wrap in existing {@code Wrapper<PrintStream>}.
      *
-     * @param interceptor the interceptor to intercept
-     * @param predicate   the predicate to apply to strings
+     * @param wrapper   the wrapper to wrap
+     * @param predicate the predicate to apply to strings
      */
-    public FilteredPrintStreamInterceptor(final PrintStreamInterceptor interceptor, final Predicate<String> predicate) {
-        super(interceptor);
+    public FilteredPrintStreamWrapper(final Wrapper<PrintStream> wrapper, @NonNull final Predicate<String> predicate) {
+        super(wrapper);
         this.predicate = predicate;
     }
 

--- a/src/main/java/net/kemitix/wrapper/printstream/RedirectPrintStreamWrapper.java
+++ b/src/main/java/net/kemitix/wrapper/printstream/RedirectPrintStreamWrapper.java
@@ -19,55 +19,52 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.kemitix.interceptor.printstream;
+package net.kemitix.wrapper.printstream;
 
 import lombok.NonNull;
+import net.kemitix.wrapper.Wrapper;
 
 import java.io.PrintStream;
 
 /**
- * Interceptor for {@link PrintStream} that copies all writes to the supplied PrintStream and on to the intercepted
- * PrintStream, or to another interceptor.
+ * Wrapper for {@link PrintStream} that Redirects all writes to the supplied PrintStream and ignores any inner
+ * wrapper and the core {@link PrintStream}.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public class CopyPrintStreamInterceptor extends PassthroughPrintStreamInterceptor {
+public class RedirectPrintStreamWrapper extends PassthroughPrintStreamWrapper {
 
-    private final PrintStream copyTo;
+    private final PrintStream redirectTo;
 
     /**
      * Constructor to intercept in existing PrintStream.
      *
-     * @param original the PrintStream to intercept
-     * @param copyTo   the PrintStream to copy writes to
+     * @param core       the PrintStream to wrap
+     * @param redirectTo the PrintStream to redirect writes to
      */
-    public CopyPrintStreamInterceptor(final PrintStream original, @NonNull final PrintStream copyTo) {
-        super(original);
-        this.copyTo = copyTo;
+    public RedirectPrintStreamWrapper(final PrintStream core, @NonNull final PrintStream redirectTo) {
+        super(core);
+        this.redirectTo = redirectTo;
     }
 
     /**
-     * Constructor to intercept in existing PrintStreamInterceptor.
+     * Constructor to intercept in existing {@code Wrapper<PrintStream>}.
      *
-     * @param interceptor the interceptor to intercept
-     * @param copyTo      the PrintStream to copy writes to
+     * @param wrapper    the wrapper to wrap
+     * @param redirectTo the PrintStream to redirect writes to
      */
-    public CopyPrintStreamInterceptor(
-            final PrintStreamInterceptor interceptor, @NonNull final PrintStream copyTo
-                                     ) {
-        super(interceptor);
-        this.copyTo = copyTo;
+    public RedirectPrintStreamWrapper(final Wrapper<PrintStream> wrapper, @NonNull final PrintStream redirectTo) {
+        super(wrapper);
+        this.redirectTo = redirectTo;
     }
 
     @Override
     public final void write(final int b) {
-        super.write(b);
-        copyTo.write(b);
+        redirectTo.write(b);
     }
 
     @Override
     public final void write(final byte[] buf, final int off, final int len) {
-        super.write(buf, off, len);
-        copyTo.write(buf, off, len);
+        redirectTo.write(buf, off, len);
     }
 }

--- a/src/main/java/net/kemitix/wrapper/printstream/package-info.java
+++ b/src/main/java/net/kemitix/wrapper/printstream/package-info.java
@@ -19,4 +19,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.kemitix.interceptor.printstream;
+package net.kemitix.wrapper.printstream;

--- a/src/test/java/net/kemitix/wrapper/printstream/CopyPrintStreamWrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/printstream/CopyPrintStreamWrapperTest.java
@@ -1,5 +1,6 @@
-package net.kemitix.interceptor.printstream;
+package net.kemitix.wrapper.printstream;
 
+import net.kemitix.wrapper.Wrapper;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,11 +14,11 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
- * Tests for {@link CopyPrintStreamInterceptor}.
+ * Tests for {@link CopyPrintStreamWrapper}.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public class CopyPrintStreamInterceptorTest {
+public class CopyPrintStreamWrapperTest {
 
     @Mock
     private PrintStream original;
@@ -25,12 +26,12 @@ public class CopyPrintStreamInterceptorTest {
     @Mock
     private PrintStream copyTo;
 
-    private PrintStreamInterceptor existing;
+    private Wrapper<PrintStream> existing;
 
     @Before
     public void setUp() {
         initMocks(this);
-        existing = new PassthroughPrintStreamInterceptor(original);
+        existing = new PassthroughPrintStreamWrapper(original);
     }
 
     @Test
@@ -52,7 +53,7 @@ public class CopyPrintStreamInterceptorTest {
         final ThrowableAssert.ThrowingCallable code = this::interceptExisting;
         //then
         assertThatNullPointerException().isThrownBy(code)
-                                        .withMessage("interceptor");
+                                        .withMessage("wrapper");
     }
 
     @Test
@@ -133,10 +134,10 @@ public class CopyPrintStreamInterceptorTest {
     }
 
     private PrintStream interceptOriginal() {
-        return new CopyPrintStreamInterceptor(original, copyTo).asPrintStream();
+        return new CopyPrintStreamWrapper(original, copyTo).asCore();
     }
 
     private PrintStream interceptExisting() {
-        return new CopyPrintStreamInterceptor(existing, copyTo).asPrintStream();
+        return new CopyPrintStreamWrapper(existing, copyTo).asCore();
     }
 }

--- a/src/test/java/net/kemitix/wrapper/printstream/PassthroughPrintStreamWrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/printstream/PassthroughPrintStreamWrapperTest.java
@@ -17,8 +17,9 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.kemitix.interceptor.printstream;
+package net.kemitix.wrapper.printstream;
 
+import net.kemitix.wrapper.Wrapper;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,11 +36,11 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
- * Tests for {@link PassthroughPrintStreamInterceptor}s.
+ * Tests for {@link PassthroughPrintStreamWrapper}s.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public class PassthroughPrintStreamInterceptorTest {
+public class PassthroughPrintStreamWrapperTest {
 
     @Mock
     private PrintStream intercepted;
@@ -52,7 +53,7 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void canWriteAByteUnmodified() {
         //given
-        final PrintStream interceptor = new TestPrintStreamInterceptor(intercepted);
+        final PrintStream interceptor = new TestPrintStreamWrapper(intercepted);
         //when
         final ThrowableAssert.ThrowingCallable code = () -> interceptor.write('x');
         //then
@@ -64,7 +65,7 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void canWriteByteArrayUnmodified() throws IOException {
         //given
-        final PrintStream interceptor = new TestPrintStreamInterceptor(intercepted);
+        final PrintStream interceptor = new TestPrintStreamWrapper(intercepted);
         //when
         final ThrowableAssert.ThrowingCallable code = () -> interceptor.write("test".getBytes());
         //then
@@ -76,7 +77,7 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void canWriteByteArraySubsectionUnmodified() throws IOException {
         //given
-        final PrintStream interceptor = new TestPrintStreamInterceptor(intercepted);
+        final PrintStream interceptor = new TestPrintStreamWrapper(intercepted);
         //when
         final ThrowableAssert.ThrowingCallable code = () -> interceptor.write("test".getBytes(), 1, 2);
         //then
@@ -88,7 +89,7 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void writeNullByteArrayWillThrowNullPointerException() throws IOException {
         //given
-        final PrintStream interceptor = new TestPrintStreamInterceptor(intercepted);
+        final PrintStream interceptor = new TestPrintStreamWrapper(intercepted);
         //when
         final ThrowableAssert.ThrowingCallable code = () -> interceptor.write(null);
         //then
@@ -98,7 +99,7 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void writeNullByteArraySubsectionWillThrowNullPointerException() {
         //given
-        final PrintStream interceptor = new TestPrintStreamInterceptor(intercepted);
+        final PrintStream interceptor = new TestPrintStreamWrapper(intercepted);
         //when
         final ThrowableAssert.ThrowingCallable code = () -> interceptor.write(null, 0, 0);
         //then
@@ -109,9 +110,9 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void canGetOriginalPrintStreamFromSingleInterceptor() {
         //given
-        final PrintStreamInterceptor interceptor = new TestPrintStreamInterceptor(intercepted);
+        final Wrapper<PrintStream> interceptor = new TestPrintStreamWrapper(intercepted);
         //when
-        final PrintStream result = interceptor.getPrintStream();
+        final PrintStream result = interceptor.getCore();
         //then
         assertThat(result).isSameAs(intercepted);
     }
@@ -119,10 +120,10 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void canGetOriginalPrintStreamThroughMultipleInterceptors() {
         //given
-        final PrintStreamInterceptor existing = new TestPrintStreamInterceptor(intercepted);
-        final PrintStreamInterceptor interceptor = new TestPrintStreamInterceptor(existing);
+        final Wrapper<PrintStream> existing = new TestPrintStreamWrapper(intercepted);
+        final Wrapper<PrintStream> interceptor = new TestPrintStreamWrapper(existing);
         //when
-        final PrintStream result = interceptor.getPrintStream();
+        final PrintStream result = interceptor.getCore();
         //then
         assertThat(result).isSameAs(intercepted);
     }
@@ -130,11 +131,11 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void writeByteToSecondInterceptorDelegatesThroughFirstToOriginal() {
         //given
-        final TestPrintStreamInterceptor existing = new TestPrintStreamInterceptor(intercepted);
-        final TestPrintStreamInterceptor interceptor =
-                new TestPrintStreamInterceptor((PrintStreamInterceptor) existing);
+        final TestPrintStreamWrapper existing = new TestPrintStreamWrapper(intercepted);
+        final TestPrintStreamWrapper interceptor =
+                new TestPrintStreamWrapper((Wrapper<PrintStream>) existing);
         //when
-        interceptor.asPrintStream()
+        interceptor.asCore()
                    .write('x');
         //then
         assertThat(interceptor.getWritten()).isEqualTo("x");
@@ -146,11 +147,11 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void writeByteArrayToSecondInterceptorDelegatesThroughFirstToOriginal() throws IOException {
         //given
-        final TestPrintStreamInterceptor existing = new TestPrintStreamInterceptor(intercepted);
-        final TestPrintStreamInterceptor interceptor =
-                new TestPrintStreamInterceptor((PrintStreamInterceptor) existing);
+        final TestPrintStreamWrapper existing = new TestPrintStreamWrapper(intercepted);
+        final TestPrintStreamWrapper interceptor =
+                new TestPrintStreamWrapper((Wrapper<PrintStream>) existing);
         //when
-        interceptor.asPrintStream()
+        interceptor.asCore()
                    .write("test".getBytes());
         //then
         assertThat(interceptor.getWritten()).isEqualTo("test");
@@ -162,11 +163,11 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void writeByteArraySubsectionToSecondInterceptorDelegatesThroughFirstToOriginal() {
         //given
-        final TestPrintStreamInterceptor existing = new TestPrintStreamInterceptor(intercepted);
-        final TestPrintStreamInterceptor interceptor =
-                new TestPrintStreamInterceptor((PrintStreamInterceptor) existing);
+        final TestPrintStreamWrapper existing = new TestPrintStreamWrapper(intercepted);
+        final TestPrintStreamWrapper interceptor =
+                new TestPrintStreamWrapper((Wrapper<PrintStream>) existing);
         //when
-        interceptor.asPrintStream()
+        interceptor.asCore()
                    .write("test".getBytes(), 1, 2);
         //then
         assertThat(interceptor.getWritten()).isEqualTo("es");
@@ -178,10 +179,10 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void canGetOriginalInterceptor() {
         //given
-        final PrintStreamInterceptor first = new TestPrintStreamInterceptor(intercepted);
-        final PrintStreamInterceptor second = new TestPrintStreamInterceptor(first);
+        final Wrapper<PrintStream> first = new TestPrintStreamWrapper(intercepted);
+        final Wrapper<PrintStream> second = new TestPrintStreamWrapper(first);
         //when
-        final Optional<PrintStreamInterceptor> result = second.getWrappedInterceptor();
+        final Optional<Wrapper<PrintStream>> result = second.findInnerWrapper();
         //then
         assertThat(result).contains(first);
     }
@@ -189,14 +190,14 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void whenTwoInterceptorsAndFirstIsRemovedThenCanWriteByte() throws IOException {
         //given
-        final TestPrintStreamInterceptor first = new TestPrintStreamInterceptor(intercepted);
-        final TestPrintStreamInterceptor second = new TestPrintStreamInterceptor((PrintStreamInterceptor) first);
+        final TestPrintStreamWrapper first = new TestPrintStreamWrapper(intercepted);
+        final Wrapper<PrintStream> second = new TestPrintStreamWrapper((Wrapper<PrintStream>) first);
         //when
         second.remove(first);
-        second.asPrintStream()
+        second.asCore()
               .write('x');
         //then
-        assertThat(second.getWrappedInterceptor()).isEmpty();
+        assertThat(second.findInnerWrapper()).isEmpty();
         assertThat(first.getWritten()).isEmpty();
         then(intercepted).should()
                          .write('x');
@@ -205,14 +206,14 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void whenTwoInterceptorsAndFirstIsRemovedThenCanWriteByteArray() throws IOException {
         //given
-        final TestPrintStreamInterceptor first = new TestPrintStreamInterceptor(intercepted);
-        final TestPrintStreamInterceptor second = new TestPrintStreamInterceptor((PrintStreamInterceptor) first);
+        final TestPrintStreamWrapper first = new TestPrintStreamWrapper(intercepted);
+        final Wrapper<PrintStream> second = new TestPrintStreamWrapper((Wrapper<PrintStream>) first);
         //when
         second.remove(first);
-        second.asPrintStream()
+        second.asCore()
               .write("test".getBytes());
         //then
-        assertThat(second.getWrappedInterceptor()).isEmpty();
+        assertThat(second.findInnerWrapper()).isEmpty();
         assertThat(first.getWritten()).isEmpty();
         then(intercepted).should()
                          .write("test".getBytes(), 0, 4);
@@ -221,14 +222,14 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void whenTwoInterceptorsAndFirstIsRemovedThenCanWriteByteArraySubset() throws IOException {
         //given
-        final TestPrintStreamInterceptor first = new TestPrintStreamInterceptor(intercepted);
-        final TestPrintStreamInterceptor second = new TestPrintStreamInterceptor((PrintStreamInterceptor) first);
+        final TestPrintStreamWrapper first = new TestPrintStreamWrapper(intercepted);
+        final Wrapper<PrintStream> second = new TestPrintStreamWrapper((Wrapper<PrintStream> )first);
         //when
         second.remove(first);
-        second.asPrintStream()
+        second.asCore()
               .write("test".getBytes(), 1, 2);
         //then
-        assertThat(second.getWrappedInterceptor()).isEmpty();
+        assertThat(second.findInnerWrapper()).isEmpty();
         assertThat(first.getWritten()).isEmpty();
         then(intercepted).should()
                          .write("test".getBytes(), 1, 2);
@@ -237,34 +238,34 @@ public class PassthroughPrintStreamInterceptorTest {
     @Test
     public void whenRemoveInterceptorIsNullThenThrowNullException() {
         //given
-        final PrintStreamInterceptor first = new TestPrintStreamInterceptor(intercepted);
-        final PrintStreamInterceptor second = new TestPrintStreamInterceptor(first);
+        final Wrapper<PrintStream> first = new TestPrintStreamWrapper(intercepted);
+        final Wrapper<PrintStream> second = new TestPrintStreamWrapper(first);
         //when
         assertThatNullPointerException().isThrownBy(() -> second.remove(null))
-                                        .withMessage("interceptor");
+                                        .withMessage("wrapper");
     }
 
     @Test public void whenThreeInterceptorsAndFirstIsRemovedThenOthersRemain() {
         //given
-        final TestPrintStreamInterceptor first = new TestPrintStreamInterceptor(intercepted);
-        final TestPrintStreamInterceptor second = new TestPrintStreamInterceptor(((PrintStreamInterceptor) first));
-        final TestPrintStreamInterceptor third = new TestPrintStreamInterceptor(((PrintStreamInterceptor) second));
+        final Wrapper<PrintStream> first = new TestPrintStreamWrapper(intercepted);
+        final Wrapper<PrintStream> second = new TestPrintStreamWrapper(first);
+        final Wrapper<PrintStream> third = new TestPrintStreamWrapper(second);
         //when
         third.remove(first);
         //then
-        assertThat(third.getWrappedInterceptor()).contains(second);
-        assertThat(second.getWrappedInterceptor()).isEmpty();
+        assertThat(third.findInnerWrapper()).contains(second);
+        assertThat(second.findInnerWrapper()).isEmpty();
     }
 
-    private class TestPrintStreamInterceptor extends PassthroughPrintStreamInterceptor {
+    private class TestPrintStreamWrapper extends PassthroughPrintStreamWrapper {
 
         private StringBuilder bytesWritten = new StringBuilder();
 
-        TestPrintStreamInterceptor(final PrintStream out) {
+        TestPrintStreamWrapper(final PrintStream out) {
             super(out);
         }
 
-        TestPrintStreamInterceptor(final PrintStreamInterceptor interceptor) {
+        TestPrintStreamWrapper(final Wrapper<PrintStream> interceptor) {
             super(interceptor);
         }
 

--- a/src/test/java/net/kemitix/wrapper/printstream/RedirectPrintStreamWrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/printstream/RedirectPrintStreamWrapperTest.java
@@ -1,5 +1,6 @@
-package net.kemitix.interceptor.printstream;
+package net.kemitix.wrapper.printstream;
 
+import net.kemitix.wrapper.Wrapper;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,11 +15,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
- * Tests for {@link CopyPrintStreamInterceptor}.
+ * Tests for {@link CopyPrintStreamWrapper}.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public class RedirectPrintStreamInterceptorTest {
+public class RedirectPrintStreamWrapperTest {
 
     @Mock
     private PrintStream original;
@@ -26,12 +27,12 @@ public class RedirectPrintStreamInterceptorTest {
     @Mock
     private PrintStream redirectTo;
 
-    private PrintStreamInterceptor existing;
+    private Wrapper<PrintStream> existing;
 
     @Before
     public void setUp() {
         initMocks(this);
-        existing = new PassthroughPrintStreamInterceptor(original);
+        existing = new PassthroughPrintStreamWrapper(original);
     }
 
     @Test
@@ -53,7 +54,7 @@ public class RedirectPrintStreamInterceptorTest {
         final ThrowableAssert.ThrowingCallable code = this::interceptExisting;
         //then
         assertThatNullPointerException().isThrownBy(code)
-                                        .withMessage("interceptor");
+                                        .withMessage("wrapper");
     }
 
     @Test
@@ -134,10 +135,10 @@ public class RedirectPrintStreamInterceptorTest {
     }
 
     private PrintStream interceptOriginal() {
-        return new RedirectPrintStreamInterceptor(original, redirectTo).asPrintStream();
+        return new RedirectPrintStreamWrapper(original, redirectTo).asCore();
     }
 
     private PrintStream interceptExisting() {
-        return new RedirectPrintStreamInterceptor(existing, redirectTo).asPrintStream();
+        return new RedirectPrintStreamWrapper(existing, redirectTo).asCore();
     }
 }


### PR DESCRIPTION
This will allow creating wrappers for objects other than `PrintStream`.