### PR TITLE
PassthroughPrintStreamWrapper: forEachByteInBuffer(): added

### DIFF
--- a/src/main/java/net/kemitix/wrapper/printstream/ByteFilterPrintStreamWrapper.java
+++ b/src/main/java/net/kemitix/wrapper/printstream/ByteFilterPrintStreamWrapper.java
@@ -74,8 +74,6 @@ public class ByteFilterPrintStreamWrapper extends PassthroughPrintStreamWrapper 
 
     @Override
     public final void write(final byte[] buf, final int off, final int len) {
-        for (int i = off; i <= off + len - 1; i++) {
-            write(buf[i]);
-        }
+        forEachByteInBuffer(buf, off, len, this::write);
     }
 }

--- a/src/main/java/net/kemitix/wrapper/printstream/ByteTransformPrintStreamWrapper.java
+++ b/src/main/java/net/kemitix/wrapper/printstream/ByteTransformPrintStreamWrapper.java
@@ -72,8 +72,6 @@ public class ByteTransformPrintStreamWrapper extends PassthroughPrintStreamWrapp
 
     @Override
     public final void write(final byte[] buf, final int off, final int len) {
-        for (int i = off; i <= off + len - 1; i++) {
-            write(buf[i]);
-        }
+        forEachByteInBuffer(buf, off, len, this::write);
     }
 }

--- a/src/main/java/net/kemitix/wrapper/printstream/PassthroughPrintStreamWrapper.java
+++ b/src/main/java/net/kemitix/wrapper/printstream/PassthroughPrintStreamWrapper.java
@@ -27,6 +27,7 @@ import net.kemitix.wrapper.WrapperState;
 
 import java.io.PrintStream;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Basic wrapper for {@link PrintStream} that simply passes all writes to the intercepted PrintStream, or to another
@@ -103,5 +104,25 @@ public class PassthroughPrintStreamWrapper extends PrintStream implements Wrappe
     @Override
     public final WrapperState<PrintStream> getWrapperState() {
         return wrapperState;
+    }
+
+    /**
+     * Scan the buffer, from off to len, and give it to the byteConsumer.
+     *
+     * @param buf          the buffer to process
+     * @param off          the offset within the buffer to begin
+     * @param len          the number of bytes to process
+     * @param byteConsumer the consumer to process each byte
+     */
+    protected final void forEachByteInBuffer(
+            final byte[] buf, final int off, final int len, final Consumer<Byte> byteConsumer
+                                            ) {
+        if (len < 0) {
+            throw new IndexOutOfBoundsException(
+                    String.format("buf.length: %d, off: %d, len: %d", buf.length, off, len));
+        }
+        for (int i = 0; i < len; i++) {
+            byteConsumer.accept(buf[off + i]);
+        }
     }
 }

--- a/src/test/java/net/kemitix/wrapper/printstream/PassthroughPrintStreamWrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/printstream/PassthroughPrintStreamWrapperTest.java
@@ -21,6 +21,7 @@ package net.kemitix.wrapper.printstream;
 
 import net.kemitix.wrapper.Wrapper;
 import net.kemitix.wrapper.WrapperState;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,8 +29,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 /**
@@ -133,5 +136,105 @@ public class PassthroughPrintStreamWrapperTest {
         //then
         assertThat(redirectTo.toString()).isEqualTo("test");
         assertThat(out.toString()).isEmpty();
+    }
+
+    @Test
+    public void whenOffsetAndLengthGreaterThenBufLengthThenThrowException() {
+        //given
+        final byte[] buf = "test".getBytes();
+        final int off = 1;
+        final int len = 4;
+        final PassthroughPrintStreamWrapper wrapper = new PassthroughPrintStreamWrapper(original);
+        //when
+        final ThrowableAssert.ThrowingCallable code = () -> wrapper.forEachByteInBuffer(buf, off, len, o -> {
+        });
+        //then
+        assertThatCode(code).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void whenOffsetLessThanZeroThenThrowException() {
+        //given
+        final byte[] buf = "test".getBytes();
+        final int off = -1;
+        final int len = 4;
+        final PassthroughPrintStreamWrapper wrapper = new PassthroughPrintStreamWrapper(original);
+        //when
+        final ThrowableAssert.ThrowingCallable code = () -> wrapper.forEachByteInBuffer(buf, off, len, o -> {
+        });
+        //then
+        assertThatCode(code).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void whenLengthIsZeroThenIsValid() {
+        //given
+        final byte[] buf = "test".getBytes();
+        final int off = 3;
+        final int len = 0;
+        final PassthroughPrintStreamWrapper wrapper = new PassthroughPrintStreamWrapper(original);
+        final ThrowableAssert.ThrowingCallable code = () -> {
+            //when
+            wrapper.forEachByteInBuffer(buf, off, len, o -> {
+            });
+        };
+        //then
+        assertThatCode(code).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void whenLengthLessThanZeroThenThrowException() {
+        //given
+        final byte[] buf = "test".getBytes();
+        final int off = 3;
+        final int len = -1;
+        final PassthroughPrintStreamWrapper wrapper = new PassthroughPrintStreamWrapper(original);
+        //when
+        final ThrowableAssert.ThrowingCallable code = () -> wrapper.forEachByteInBuffer(buf, off, len, o -> {
+        });
+        //then
+        assertThatCode(code).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void whenOffsetGreaterThanBufLengthThenThrowException() {
+        //given
+        final byte[] buf = "test".getBytes();
+        final int off = 4;
+        final int len = 1;
+        final PassthroughPrintStreamWrapper wrapper = new PassthroughPrintStreamWrapper(original);
+        //when
+        final ThrowableAssert.ThrowingCallable code = () -> wrapper.forEachByteInBuffer(buf, off, len, o -> {
+        });
+        //then
+        assertThatCode(code).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void whenLengthGreaterThanBufLengthThenThrowException() {
+        //given
+        final byte[] buf = "test".getBytes();
+        final int off = 0;
+        final int len = 5;
+        final PassthroughPrintStreamWrapper wrapper = new PassthroughPrintStreamWrapper(original);
+        //when
+        final ThrowableAssert.ThrowingCallable code = () -> wrapper.forEachByteInBuffer(buf, off, len, o -> {
+        });
+        //then
+        assertThatCode(code).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void whenOffsetAndLengthMatchFullBufThenIsValid() {
+        //given
+        final byte[] buf = "test".getBytes();
+        final int off = 0;
+        final int len = 4;
+        final PassthroughPrintStreamWrapper wrapper = new PassthroughPrintStreamWrapper(original);
+        final AtomicBoolean aBoolean = new AtomicBoolean();
+        //when
+        wrapper.forEachByteInBuffer(buf, off, len, o -> aBoolean.set(true));
+        //then
+        assertThat(aBoolean).isTrue();
     }
 }


### PR DESCRIPTION
Refactored from duplicate code in `Byte{Filter,Transform}PrintStreamWrapper.write(buf, off, len)` methods.